### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,26 +61,6 @@
 								<port>${lean-jetty.port}</port>
 							</httpConnector>
 						</configuration>
-						<executions>
-							<execution>
-								<id>start-jetty</id>
-								<phase>pre-integration-test</phase>
-								<goals>
-									<goal>run</goal>
-								</goals>
-								<configuration>
-									<scanIntervalSeconds>0</scanIntervalSeconds>
-									<daemon>true</daemon>
-								</configuration>
-							</execution>
-							<execution>
-								<id>stop-jetty</id>
-								<phase>post-integration-test</phase>
-								<goals>
-									<goal>stop</goal>
-								</goals>
-							</execution>
-						</executions>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<jettyVersion>9.3.10.v20160621</jettyVersion>
 	</properties>
 
@@ -34,51 +36,54 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
-				<version>${jettyVersion}</version>
-				<configuration>
-					<webAppSourceDirectory>${project.basedir}/src/main/webapp</webAppSourceDirectory>
-					<scanIntervalSeconds>3</scanIntervalSeconds>
-					<stopKey>foo</stopKey>
-					<stopPort>9999</stopPort>
-					<httpConnector>
-						<port>${env.LEANCLOUD_APP_PORT}</port>
-					</httpConnector>
-				</configuration>
-				<executions>
-					<execution>
-						<id>start-jetty</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
+	<profiles>
+		<profile>
+			<id>lean-jetty</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<properties>
+				<lean-jetty.version>9.3.10.v20160621</lean-jetty.version>
+				<lean-jetty.port>${env.LEANCLOUD_APP_PORT}</lean-jetty.port>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jetty</groupId>
+						<artifactId>jetty-maven-plugin</artifactId>
+						<version>${lean-jetty.version}</version>
 						<configuration>
-							<scanIntervalSeconds>0</scanIntervalSeconds>
-							<daemon>true</daemon>
+							<webAppSourceDirectory>${project.basedir}/src/main/webapp</webAppSourceDirectory>
+							<scanIntervalSeconds>3</scanIntervalSeconds>
+							<stopKey>foo</stopKey>
+							<stopPort>9999</stopPort>
+							<httpConnector>
+								<port>${lean-jetty.port}</port>
+							</httpConnector>
 						</configuration>
-					</execution>
-					<execution>
-						<id>stop-jetty</id>
-						<phase>post-integration-test</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+						<executions>
+							<execution>
+								<id>start-jetty</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<scanIntervalSeconds>0</scanIntervalSeconds>
+									<daemon>true</daemon>
+								</configuration>
+							</execution>
+							<execution>
+								<id>stop-jetty</id>
+								<phase>post-integration-test</phase>
+								<goals>
+									<goal>stop</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
 	<profiles>
 		<profile>
-			<id>lean-jetty</id>
+			<id>lean-up</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>


### PR DESCRIPTION
目的在于降低 pom.xml 的入侵

+ 在 properties 中设置 java 版本
+ Jetty 的一些配置移入 profile `lean-jetty`

说明: 

+ 在 properties 中设置参数, 是非常友好的一种方式, 因为可以轻易在命令行,或者是 profile 中对其进行覆盖

+ Jetty 的配置移入 profile, 用户也可以达到让用户自主选择的目的, 只需要将 `<activeByDefault>true</activeByDefault>` 置为`false` 即可关闭

+ 去掉 lean-up 里的 executions,  如果只给`lean up` 使用的话, 是不需要 executions 的.

> lean up 是 调用了 `mvn jetty:start`, 只需要引入 `jetty-maven-plugin` 然后保证配置正确就可以了

+ 另外 `lean-jetty` 并非是必须激活的, 设置为默认激活, 只为了 `lean up`, 或许我们可以 让 `lean up` 的时候主动传入 `-Plean-jetty` 来避免默认激活 `lean-jetty`
